### PR TITLE
chore(front): add API key for GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,8 @@ jobs:
       - name: Build
         working-directory: ./frontend
         run: npm run build
+        env:
+          VITE_APP_UNSPLASH_ACCESS_KEY: ${{ secrets.VITE_APP_UNSPLASH_ACCESS_KEY }}
 
       - name: Deploy to server
         uses: burnett01/rsync-deployments@6.0.0


### PR DESCRIPTION
@IvanSitnikov1 можешь в секреты GitHub добавить переменную `VITE_APP_UNSPLASH_ACCESS_KEY` с Access ключом для Unsplash? До этого она называлась `REACT_APP_UNSPLASH_ACCESS_KEY`